### PR TITLE
feat: Implement dark mode with toggle

### DIFF
--- a/themes/artemis/layout/partial/nav.pug
+++ b/themes/artemis/layout/partial/nav.pug
@@ -6,3 +6,5 @@ ul.nav.nav-list
             - var act = !re.test(value) && '/' + page.current_url === value
             a.nav-list-link(class={active: act} href=url_for(value), target=tar)
                 != key.toUpperCase()
+    li.nav-list-item
+        a.nav-list-link#theme-toggle-button(href="#") Toggle Mode

--- a/themes/artemis/layout/partial/scripts.pug
+++ b/themes/artemis/layout/partial/scripts.pug
@@ -39,3 +39,41 @@ script.
     window.location.href = '/';
   }
 
+// Theme toggle script
+script.
+  (function() {
+    var body = document.body;
+    var toggleButton = document.getElementById('theme-toggle-button');
+
+    if (!toggleButton) {
+      console.error('Theme toggle button not found');
+      return;
+    }
+
+    // Function to apply the theme based on localStorage
+    function applyInitialTheme() {
+      var storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        body.classList.add('dark-mode');
+      } else {
+        body.classList.remove('dark-mode'); // Explicitly set light by removing dark
+      }
+    }
+
+    // Apply theme on initial load
+    applyInitialTheme();
+
+    // Event listener for the toggle button
+    toggleButton.addEventListener('click', function(event) {
+      event.preventDefault(); // If using an <a> tag for the button
+      body.classList.toggle('dark-mode');
+
+      // Update localStorage
+      if (body.classList.contains('dark-mode')) {
+        localStorage.setItem('theme', 'dark');
+      } else {
+        localStorage.setItem('theme', 'light');
+      }
+    });
+  })();
+

--- a/themes/artemis/source/scss/_partial/_dark.scss
+++ b/themes/artemis/source/scss/_partial/_dark.scss
@@ -1,0 +1,32 @@
+// themes/artemis/source/scss/_partial/_dark.scss
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+
+  a {
+    color: #bb86fc;
+  }
+
+  // Add more specific styles for other elements as needed
+  // For example, header, footer, posts, code blocks, etc.
+
+  .header { // Example: Assuming a .header class exists
+    background-color: #1f1f1f;
+    border-bottom: 1px solid #333;
+  }
+
+  .article-entry { // Example: For article content
+    a {
+      color: #bb86fc;
+      &:hover {
+        color: #9e6bff;
+      }
+    }
+  }
+
+  code, pre {
+    background-color: #1e1e1e;
+    color: #d4d4d4;
+    border: 1px solid #333;
+  }
+}

--- a/themes/artemis/source/scss/theme.scss
+++ b/themes/artemis/source/scss/theme.scss
@@ -12,3 +12,4 @@
 @import "_partial/mq";
 @import "_partial/copyright";
 @import "_partial/highlight";
+@import "_partial/dark";


### PR DESCRIPTION
This commit introduces a dark mode feature to the Artemis theme.

Key changes:
- Added a new SCSS partial `_dark.scss` with styles for dark mode.
- Imported dark mode styles into the main `theme.scss`.
- Added a toggle button to the navigation bar (`nav.pug`) to switch between light and dark themes.
- Implemented JavaScript logic in `scripts.pug` to handle:
    - Theme toggling on button click.
    - Persisting the theme preference in localStorage.
    - Applying the stored theme on page load.